### PR TITLE
Restrict variation assets to product edit screen

### DIFF
--- a/woo-laser-photo-mockup/includes/class-llp-variation-fields.php
+++ b/woo-laser-photo-mockup/includes/class-llp-variation-fields.php
@@ -15,9 +15,16 @@ class LLP_Variation_Fields {
      * Enqueue admin scripts for media uploader and field handling.
      */
     public function enqueue_admin_scripts( $hook ) {
-        if ( 'product_page_product_variation' !== $hook && 'post.php' !== $hook && 'post-new.php' !== $hook ) {
-            // Only enqueue on product edit screen.
+        // Only enqueue scripts on product edit screens.
+        if ( ! in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
+            return;
         }
+
+        $screen = get_current_screen();
+        if ( empty( $screen ) || 'product' !== $screen->post_type ) {
+            return;
+        }
+
         wp_enqueue_media();
         wp_enqueue_style( 'llp-admin', LLP_PLUGIN_URL . 'assets/css/admin.css', [], '1.0.0' );
         wp_enqueue_script( 'llp-admin-variation', LLP_PLUGIN_URL . 'assets/js/admin-variation.js', [ 'jquery' ], '1.0.0', true );


### PR DESCRIPTION
## Summary
- Only enqueue variation assets on product edit pages

## Testing
- `php -l woo-laser-photo-mockup/includes/class-llp-variation-fields.php`
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e98615188333bed004188c829817