### PR TITLE
Handle transform data and variation ID in finalize endpoint

### DIFF
--- a/woo-laser-photo-mockup/assets/js/frontend.js
+++ b/woo-laser-photo-mockup/assets/js/frontend.js
@@ -4,6 +4,26 @@ jQuery(function($){
     var img       = $('#llp-preview img');
     var assetField = $('#llp-asset-id');
     var thumbField = $('#llp-thumb-url');
+    var currentVariation = $('input.variation_id').val() || 0;
+
+    function getTransform(){
+        var crop = {
+            x: parseFloat(img.data('crop-x')) || 0,
+            y: parseFloat(img.data('crop-y')) || 0,
+            width: parseFloat(img.data('crop-width')) || img.width(),
+            height: parseFloat(img.data('crop-height')) || img.height()
+        };
+        var scale = parseFloat(img.data('scale')) || 1;
+        var rotation = parseFloat(img.data('rotation')) || 0;
+        return { crop: crop, scale: scale, rotation: rotation };
+    }
+
+    // Track variation selection
+    $('form.variations_form').on('found_variation', function(e, variation){
+        currentVariation = variation.variation_id || 0;
+    }).on('reset_data', function(){
+        currentVariation = 0;
+    });
 
     fileInput.on('change', function(){
         var file = this.files[0];
@@ -17,15 +37,14 @@ jQuery(function($){
         }).then(resp => resp.json()).then(function(res){
             if(res.asset_id){
                 assetField.val(res.asset_id);
-                // Finalize immediately with dummy transform; real app would send user transform data
-                var variation = $('input.variation_id').val() || 0;
+                var transform = getTransform();
                 fetch(llpVars.restUrl + '/finalize', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
                         'X-WP-Nonce': llpVars.nonce
                     },
-                    body: JSON.stringify({asset_id: res.asset_id, variation_id: variation, transform: {}})
+                    body: JSON.stringify({asset_id: res.asset_id, variation_id: currentVariation, transform: transform})
                 }).then(r => r.json()).then(function(res2){
                     if(res2.thumb){
                         img.attr('src', res2.thumb);


### PR DESCRIPTION
## Summary
- Capture crop, scale, and rotation data on the frontend and track selected variation
- Validate transform structure and variation IDs in REST finalize handler

## Testing
- `php -l woo-laser-photo-mockup/includes/class-llp-rest.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ea5d24c08333a53f7ad475f5e8bc