### PR TITLE
Support advanced transforms and masks in renderer

### DIFF
--- a/woo-laser-photo-mockup/includes/class-llp-renderer.php
+++ b/woo-laser-photo-mockup/includes/class-llp-renderer.php
@@ -27,25 +27,95 @@ class LLP_Renderer {
         $bounds = get_post_meta( $variation_id, '_llp_bounds', true );
         $bounds = $bounds ? json_decode( $bounds, true ) : [ 'x' => 0, 'y' => 0, 'width' => 100, 'height' => 100, 'rotation' => 0 ];
 
-        $base = imagecreatefrompng( $base_path );
+        // Parse transform for scale/position/rotation.
+        $scale    = 1;
+        $rotation = 0;
+        $position = [ 'x' => 0, 'y' => 0 ];
+        if ( is_string( $transform ) ) {
+            if ( preg_match( '/scale\((-?[0-9\.]+)\)/', $transform, $m ) ) {
+                $scale = floatval( $m[1] );
+            }
+            if ( preg_match( '/translate\((-?[0-9\.]+)\s*,\s*(-?[0-9\.]+)\)/', $transform, $m ) ) {
+                $position['x'] = floatval( $m[1] );
+                $position['y'] = floatval( $m[2] );
+            }
+            if ( preg_match( '/rotate\((-?[0-9\.]+)\)/', $transform, $m ) ) {
+                $rotation = floatval( $m[1] );
+            }
+        } elseif ( is_array( $transform ) ) {
+            $scale    = isset( $transform['scale'] ) ? floatval( $transform['scale'] ) : 1;
+            $rotation = isset( $transform['rotation'] ) ? floatval( $transform['rotation'] ) : 0;
+            if ( isset( $transform['position'] ) && is_array( $transform['position'] ) ) {
+                $position['x'] = floatval( $transform['position']['x'] ?? 0 );
+                $position['y'] = floatval( $transform['position']['y'] ?? 0 );
+            }
+        }
+
+        // Detect base mime type and create image accordingly.
+        $info = getimagesize( $base_path );
+        if ( ! $info ) {
+            return new WP_Error( 'img', __( 'Could not read base image', 'llp' ) );
+        }
+        switch ( $info[2] ) {
+            case IMAGETYPE_JPEG:
+                $base = imagecreatefromjpeg( $base_path );
+                break;
+            case IMAGETYPE_GIF:
+                $base = imagecreatefromgif( $base_path );
+                break;
+            default:
+                $base = imagecreatefrompng( $base_path );
+                break;
+        }
+
         $user = imagecreatefromstring( file_get_contents( $paths['original'] ) );
         if ( ! $base || ! $user ) {
             return new WP_Error( 'img', __( 'Could not create images', 'llp' ) );
         }
 
         // Resize user image to bounds.
-        $dst_w = intval( $bounds['width'] );
-        $dst_h = intval( $bounds['height'] );
+        $dst_w = intval( $bounds['width'] * $scale );
+        $dst_h = intval( $bounds['height'] * $scale );
         $tmp   = imagecreatetruecolor( $dst_w, $dst_h );
+        imagesavealpha( $tmp, true );
+        imagealphablending( $tmp, false );
         imagecopyresampled( $tmp, $user, 0, 0, 0, 0, $dst_w, $dst_h, imagesx( $user ), imagesy( $user ) );
 
         // Rotate if needed.
-        if ( ! empty( $bounds['rotation'] ) ) {
-            $tmp = imagerotate( $tmp, -floatval( $bounds['rotation'] ), 0 );
+        $total_rotation = floatval( $bounds['rotation'] ) + $rotation;
+        if ( 0 !== $total_rotation ) {
+            $tmp = imagerotate( $tmp, -$total_rotation, 0 );
+        }
+
+        // Apply mask if defined.
+        $mask_id   = get_post_meta( $variation_id, '_llp_mask_image_id', true );
+        $mask_path = $mask_id ? get_attached_file( $mask_id ) : '';
+        if ( $mask_path && file_exists( $mask_path ) ) {
+            $mask_info = getimagesize( $mask_path );
+            switch ( $mask_info[2] ) {
+                case IMAGETYPE_JPEG:
+                    $mask = imagecreatefromjpeg( $mask_path );
+                    break;
+                case IMAGETYPE_GIF:
+                    $mask = imagecreatefromgif( $mask_path );
+                    break;
+                default:
+                    $mask = imagecreatefrompng( $mask_path );
+                    break;
+            }
+            if ( $mask ) {
+                $resized = imagecreatetruecolor( imagesx( $tmp ), imagesy( $tmp ) );
+                imagecopyresampled( $resized, $mask, 0, 0, 0, 0, imagesx( $tmp ), imagesy( $tmp ), imagesx( $mask ), imagesy( $mask ) );
+                $tmp = $this->apply_mask( $tmp, $resized );
+                imagedestroy( $mask );
+                imagedestroy( $resized );
+            }
         }
 
         // Merge into base.
-        imagecopy( $base, $tmp, intval( $bounds['x'] ), intval( $bounds['y'] ), 0, 0, imagesx( $tmp ), imagesy( $tmp ) );
+        $dst_x = intval( $bounds['x'] + $position['x'] );
+        $dst_y = intval( $bounds['y'] + $position['y'] );
+        imagecopy( $base, $tmp, $dst_x, $dst_y, 0, 0, imagesx( $tmp ), imagesy( $tmp ) );
 
         // Save composite.
         $storage->ensure_asset_dir( $asset_id );
@@ -68,5 +138,31 @@ class LLP_Renderer {
             'composite' => $storage->url_for( $asset_id, 'composite' ),
             'thumb'     => $storage->url_for( $asset_id, 'thumb' ),
         ];
+    }
+
+    /**
+     * Apply alpha mask to image.
+     *
+     * @param resource $image Image resource to mask.
+     * @param resource $mask  Mask image resource.
+     * @return resource
+     */
+    protected function apply_mask( $image, $mask ) {
+        $width  = imagesx( $image );
+        $height = imagesy( $image );
+        imagesavealpha( $image, true );
+        imagealphablending( $image, false );
+
+        for ( $x = 0; $x < $width; $x++ ) {
+            for ( $y = 0; $y < $height; $y++ ) {
+                $mask_color = imagecolorsforindex( $mask, imagecolorat( $mask, $x, $y ) );
+                $img_color  = imagecolorsforindex( $image, imagecolorat( $image, $x, $y ) );
+                $alpha      = $mask_color['alpha'];
+                $color      = imagecolorallocatealpha( $image, $img_color['red'], $img_color['green'], $img_color['blue'], $alpha );
+                imagesetpixel( $image, $x, $y, $color );
+            }
+        }
+
+        return $image;
     }
 }


### PR DESCRIPTION
## Summary
- Parse transform string/array to extract scale, position, and rotation before compositing
- Detect base image mime types to open JPEG, GIF, or PNG sources appropriately
- Apply optional mask image to the resized user image prior to merging

## Testing
- `php -l includes/class-llp-renderer.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4eb6072c483338d8f70ff3c0f556d