### PR TITLE
Add stricter upload validation and image sanitization

### DIFF
--- a/woo-laser-photo-mockup/includes/class-llp-security.php
+++ b/woo-laser-photo-mockup/includes/class-llp-security.php
@@ -12,19 +12,34 @@ class LLP_Security {
         if ( $file['error'] !== UPLOAD_ERR_OK ) {
             return new WP_Error( 'upload', __( 'Upload error', 'llp' ) );
         }
-        $allowed = explode( ',', LLP_Settings::get( 'allowed_mimes', 'jpg,jpeg,png,webp' ) );
-        $ext     = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
-        if ( ! in_array( $ext, $allowed, true ) ) {
+        $allowed   = explode( ',', LLP_Settings::get( 'allowed_mimes', 'jpg,jpeg,png,webp' ) );
+        $ext       = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
+        $wp_file   = wp_check_filetype( $file['name'] );
+
+        if ( ! in_array( $ext, $allowed, true ) || empty( $wp_file['type'] ) ) {
             return new WP_Error( 'mime', __( 'File type not allowed', 'llp' ) );
         }
+
+        $finfo = finfo_open( FILEINFO_MIME_TYPE );
+        $mime  = $finfo ? finfo_file( $finfo, $file['tmp_name'] ) : '';
+        if ( $finfo ) {
+            finfo_close( $finfo );
+        }
+
+        if ( $mime !== $wp_file['type'] ) {
+            return new WP_Error( 'mime', __( 'File type mismatch', 'llp' ) );
+        }
+
         $max_size = LLP_Settings::get( 'max_file_size', 15 ) * 1024 * 1024;
         if ( $file['size'] > $max_size ) {
             return new WP_Error( 'size', __( 'File too large', 'llp' ) );
         }
+
         $info = getimagesize( $file['tmp_name'] );
         if ( false === $info ) {
             return new WP_Error( 'img', __( 'Invalid image', 'llp' ) );
         }
+
         return true;
     }
 }

--- a/woo-laser-photo-mockup/includes/class-llp-storage.php
+++ b/woo-laser-photo-mockup/includes/class-llp-storage.php
@@ -14,21 +14,98 @@ class LLP_Storage {
         $asset_id = wp_generate_uuid4();
         $dir      = $this->asset_dir( $asset_id );
         wp_mkdir_p( $dir );
-        $ext     = pathinfo( $file['name'], PATHINFO_EXTENSION );
-        $dest    = $dir . 'original.' . $ext;
-        if ( ! move_uploaded_file( $file['tmp_name'], $dest ) ) {
-            return new WP_Error( 'move', __( 'Could not move uploaded file', 'llp' ) );
+
+        $finfo = finfo_open( FILEINFO_MIME_TYPE );
+        $mime  = $finfo ? finfo_file( $finfo, $file['tmp_name'] ) : '';
+        if ( $finfo ) {
+            finfo_close( $finfo );
         }
+
+        $ext  = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
+        $dest = $dir . 'original.' . $ext;
+
+        $processed = $this->reencode_image( $file['tmp_name'], $dest, $mime );
+        if ( is_wp_error( $processed ) ) {
+            return $processed;
+        }
+
+        @unlink( $file['tmp_name'] );
+
         $meta = [
             'asset_id' => $asset_id,
             'original_path' => $dest,
         ];
         file_put_contents( $dir . 'meta.json', wp_json_encode( $meta ) );
+
         return [
-            'asset_id'    => $asset_id,
-            'original'    => $this->url_for( $asset_id, 'original.' . $ext ),
+            'asset_id'        => $asset_id,
+            'original'        => $this->url_for( $asset_id, 'original.' . $ext ),
             'original_sha256' => hash_file( 'sha256', $dest ),
         ];
+    }
+
+    /**
+     * Re-encode image, strip metadata and normalise orientation.
+     */
+    private function reencode_image( $source, $dest, $mime ) {
+        switch ( $mime ) {
+            case 'image/jpeg':
+                $image = imagecreatefromjpeg( $source );
+                if ( ! $image ) {
+                    return new WP_Error( 'img', __( 'Invalid image', 'llp' ) );
+                }
+                if ( function_exists( 'exif_read_data' ) ) {
+                    $exif = @exif_read_data( $source );
+                    if ( ! empty( $exif['Orientation'] ) ) {
+                        switch ( (int) $exif['Orientation'] ) {
+                            case 3:
+                                $image = imagerotate( $image, 180, 0 );
+                                break;
+                            case 6:
+                                $image = imagerotate( $image, -90, 0 );
+                                break;
+                            case 8:
+                                $image = imagerotate( $image, 90, 0 );
+                                break;
+                        }
+                    }
+                }
+                if ( false === imagejpeg( $image, $dest, 100 ) ) {
+                    imagedestroy( $image );
+                    return new WP_Error( 'encode', __( 'Could not save image', 'llp' ) );
+                }
+                imagedestroy( $image );
+                break;
+            case 'image/png':
+                $image = imagecreatefrompng( $source );
+                if ( ! $image ) {
+                    return new WP_Error( 'img', __( 'Invalid image', 'llp' ) );
+                }
+                if ( false === imagepng( $image, $dest ) ) {
+                    imagedestroy( $image );
+                    return new WP_Error( 'encode', __( 'Could not save image', 'llp' ) );
+                }
+                imagedestroy( $image );
+                break;
+            case 'image/webp':
+                if ( ! function_exists( 'imagecreatefromwebp' ) ) {
+                    return new WP_Error( 'img', __( 'WebP not supported', 'llp' ) );
+                }
+                $image = imagecreatefromwebp( $source );
+                if ( ! $image ) {
+                    return new WP_Error( 'img', __( 'Invalid image', 'llp' ) );
+                }
+                if ( false === imagewebp( $image, $dest, 100 ) ) {
+                    imagedestroy( $image );
+                    return new WP_Error( 'encode', __( 'Could not save image', 'llp' ) );
+                }
+                imagedestroy( $image );
+                break;
+            default:
+                return new WP_Error( 'mime', __( 'Unsupported image type', 'llp' ) );
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary
- verify uploaded files with `finfo` and `wp_check_filetype`
- re-encode uploads to strip metadata and normalize orientation

## Testing
- `php -l woo-laser-photo-mockup/includes/class-llp-security.php`
- `php -l woo-laser-photo-mockup/includes/class-llp-storage.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4eca5e2b48333b80004e1c63f4361