### PR TITLE
Persist asset meta on orders and refine purge handling

### DIFF
--- a/woo-laser-photo-mockup/includes/class-llp-cron.php
+++ b/woo-laser-photo-mockup/includes/class-llp-cron.php
@@ -30,7 +30,12 @@ class LLP_Cron {
             return;
         }
         $threshold = time() - ( DAY_IN_SECONDS * $retention );
+        $used       = LLP_Order::instance()->get_referenced_asset_ids();
         foreach ( glob( $base . '/*', GLOB_ONLYDIR ) as $dir ) {
+            $asset_id = basename( $dir );
+            if ( in_array( $asset_id, $used, true ) ) {
+                continue;
+            }
             if ( filemtime( $dir ) < $threshold ) {
                 $this->rrmdir( $dir );
             }

--- a/woo-laser-photo-mockup/templates/emails/line-item-preview.php
+++ b/woo-laser-photo-mockup/templates/emails/line-item-preview.php
@@ -1,7 +1,33 @@
 <?php
 /**
- * Email line item preview.
+ * Email/order item preview and meta output.
+ *
+ * @var string $thumb_url      Thumbnail URL.
+ * @var string $asset_id       Asset identifier.
+ * @var string $composite_url  Composite image URL.
+ * @var string $original_url   Original upload URL.
+ * @var string $transform_json Transform parameters JSON.
  */
-if ( ! empty( $thumb_url ) ) : ?>
+?>
+<?php if ( ! empty( $thumb_url ) ) : ?>
     <p><img src="<?php echo esc_url( $thumb_url ); ?>" alt="" style="max-width:80px;" /></p>
+<?php endif; ?>
+<?php if ( ! empty( $asset_id ) ) : ?>
+    <p><?php printf( esc_html__( 'Asset ID: %s', 'llp' ), esc_html( $asset_id ) ); ?></p>
+<?php endif; ?>
+<?php if ( ! empty( $original_url ) || ! empty( $composite_url ) ) : ?>
+    <p>
+        <?php if ( ! empty( $original_url ) ) : ?>
+            <a href="<?php echo esc_url( $original_url ); ?>"><?php esc_html_e( 'Original', 'llp' ); ?></a>
+        <?php endif; ?>
+        <?php if ( ! empty( $original_url ) && ! empty( $composite_url ) ) : ?>
+            |
+        <?php endif; ?>
+        <?php if ( ! empty( $composite_url ) ) : ?>
+            <a href="<?php echo esc_url( $composite_url ); ?>"><?php esc_html_e( 'Composite', 'llp' ); ?></a>
+        <?php endif; ?>
+    </p>
+<?php endif; ?>
+<?php if ( ! empty( $transform_json ) ) : ?>
+    <pre style="white-space:pre-wrap;"><?php echo esc_html( $transform_json ); ?></pre>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- Store asset metadata (asset ID, URLs, transform JSON) on order items and display preview info in admin and emails
- Skip purging asset directories that are referenced by existing orders

## Testing
- `php -l includes/class-llp-order.php`
- `php -l includes/class-llp-cron.php`
- `php -l templates/emails/line-item-preview.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4ef8b17a8833386e52133b652845d