### PR TITLE
Add canvas-based image editing with transform serialization

### DIFF
--- a/woo-laser-photo-mockup/assets/css/frontend.css
+++ b/woo-laser-photo-mockup/assets/css/frontend.css
@@ -1,2 +1,4 @@
 .llp-customizer { margin-bottom: 1em; }
 .llp-preview img { max-width: 100%; height: auto; display:block; }
+.llp-editor canvas { max-width:100%; border:1px solid #ccc; display:block; }
+#llp-finalize { margin-top:0.5em; }

--- a/woo-laser-photo-mockup/assets/js/frontend.js
+++ b/woo-laser-photo-mockup/assets/js/frontend.js
@@ -1,20 +1,64 @@
 jQuery(function($){
-    var fileInput = $('#llp-file');
-    var preview   = $('#llp-preview');
-    var img       = $('#llp-preview img');
-    var assetField = $('#llp-asset-id');
-    var thumbField = $('#llp-thumb-url');
+    var fileInput   = $('#llp-file');
+    var editor      = $('#llp-editor');
+    var preview     = $('#llp-preview');
+    var img         = $('#llp-preview img');
+    var finalizeBtn = $('#llp-finalize');
+    var assetField  = $('#llp-asset-id');
+    var thumbField  = $('#llp-thumb-url');
     var currentVariation = $('input.variation_id').val() || 0;
 
+    var canvas = new fabric.Canvas('llp-canvas', { selection: false });
+    var fabricImg = null;
+
+    function getBounds(){
+        if(window.llpBounds && window.llpBounds[currentVariation]){
+            return window.llpBounds[currentVariation];
+        }
+        return { x:0, y:0, width:200, height:200, rotation:0 };
+    }
+
+    function initCanvas(url){
+        var bounds = getBounds();
+        canvas.clear();
+        canvas.setWidth(bounds.width);
+        canvas.setHeight(bounds.height);
+        fabric.Image.fromURL(url, function(oImg){
+            fabricImg = oImg;
+            oImg.set({ left:0, top:0, originX:'left', originY:'top' });
+            canvas.add(oImg);
+            canvas.renderAll();
+        });
+        editor.show();
+        preview.hide();
+    }
+
+    function clamp(){
+        if(!fabricImg) return;
+        var maxLeft = 0;
+        var maxTop = 0;
+        var minLeft = canvas.width - fabricImg.getScaledWidth();
+        var minTop = canvas.height - fabricImg.getScaledHeight();
+        if(fabricImg.left > maxLeft) fabricImg.left = maxLeft;
+        if(fabricImg.top > maxTop) fabricImg.top = maxTop;
+        if(fabricImg.left < minLeft) fabricImg.left = minLeft;
+        if(fabricImg.top < minTop) fabricImg.top = minTop;
+    }
+    canvas.on('object:moving', clamp);
+    canvas.on('object:scaling', clamp);
+
     function getTransform(){
+        if(!fabricImg){
+            return { crop:{x:0,y:0,width:0,height:0}, scale:1, rotation:0 };
+        }
+        var scale = fabricImg.scaleX;
+        var rotation = fabricImg.angle;
         var crop = {
-            x: parseFloat(img.data('crop-x')) || 0,
-            y: parseFloat(img.data('crop-y')) || 0,
-            width: parseFloat(img.data('crop-width')) || img.width(),
-            height: parseFloat(img.data('crop-height')) || img.height()
+            x: -fabricImg.left / scale,
+            y: -fabricImg.top / scale,
+            width: canvas.width / scale,
+            height: canvas.height / scale
         };
-        var scale = parseFloat(img.data('scale')) || 1;
-        var rotation = parseFloat(img.data('rotation')) || 0;
         return { crop: crop, scale: scale, rotation: rotation };
     }
 
@@ -28,6 +72,11 @@ jQuery(function($){
     fileInput.on('change', function(){
         var file = this.files[0];
         if(!file) return;
+        var reader = new FileReader();
+        reader.onload = function(e){
+            initCanvas(e.target.result);
+        };
+        reader.readAsDataURL(file);
         var fd = new FormData();
         fd.append('file', file);
         fetch(llpVars.restUrl + '/upload', {
@@ -37,21 +86,26 @@ jQuery(function($){
         }).then(resp => resp.json()).then(function(res){
             if(res.asset_id){
                 assetField.val(res.asset_id);
-                var transform = getTransform();
-                fetch(llpVars.restUrl + '/finalize', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-WP-Nonce': llpVars.nonce
-                    },
-                    body: JSON.stringify({asset_id: res.asset_id, variation_id: currentVariation, transform: transform})
-                }).then(r => r.json()).then(function(res2){
-                    if(res2.thumb){
-                        img.attr('src', res2.thumb);
-                        preview.show();
-                        thumbField.val(res2.thumb);
-                    }
-                });
+            }
+        });
+    });
+
+    finalizeBtn.on('click', function(){
+        if(!assetField.val()) return;
+        var transform = getTransform();
+        fetch(llpVars.restUrl + '/finalize', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-WP-Nonce': llpVars.nonce
+            },
+            body: JSON.stringify({asset_id: assetField.val(), variation_id: currentVariation, transform: transform})
+        }).then(r => r.json()).then(function(res2){
+            if(res2.thumb){
+                img.attr('src', res2.thumb);
+                thumbField.val(res2.thumb);
+                preview.show();
+                editor.hide();
             }
         });
     });

--- a/woo-laser-photo-mockup/templates/single-product/customizer.php
+++ b/woo-laser-photo-mockup/templates/single-product/customizer.php
@@ -7,9 +7,29 @@
     <p>
         <input type="file" id="llp-file" accept="image/*" />
     </p>
+    <div id="llp-editor" class="llp-editor" style="display:none;">
+        <canvas id="llp-canvas"></canvas>
+        <p><button type="button" id="llp-finalize" class="button">Finalize</button></p>
+    </div>
     <div id="llp-preview" class="llp-preview" style="display:none;">
         <img src="" alt="" />
     </div>
     <input type="hidden" name="llp_asset_id" id="llp-asset-id" />
     <input type="hidden" name="llp_thumb_url" id="llp-thumb-url" />
 </div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.2.4/fabric.min.js" integrity="sha512-4xXHzkwmo7aX6ixkmKuuNHYsYvwdivEafgAvFp8ZUBKbjDg7sWXBJgp7wa9u0edPFsKnz03Wx/ju0RduCMsZ/Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<?php
+// Expose bounds for each variation to JS.
+global $product;
+$bounds_map = [];
+if ( $product && $product->is_type( 'variable' ) ) {
+    foreach ( $product->get_children() as $variation_id ) {
+        $bounds = get_post_meta( $variation_id, '_llp_bounds', true );
+        $bounds_map[ $variation_id ] = $bounds ? json_decode( $bounds, true ) : [];
+    }
+}
+?>
+<script>
+window.llpBounds = <?php echo wp_json_encode( $bounds_map ); ?>;
+</script>


### PR DESCRIPTION
## Summary
- Add Fabric.js canvas editor and finalize workflow to customizer template
- Enable client-side image manipulation within admin-defined bounds and serialize transform data
- Style editor canvas and finalize button for consistent frontend appearance

## Testing
- ✅ `php -l templates/single-product/customizer.php`
- ⚠️ `npm test` (package.json missing)
- ⚠️ `phpunit` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a4f0bc74188333a51e850eaa0d63db