### PR TITLE
Load variation scripts only on product edit

### DIFF
--- a/woo-laser-photo-mockup/includes/class-llp-variation-fields.php
+++ b/woo-laser-photo-mockup/includes/class-llp-variation-fields.php
@@ -15,13 +15,9 @@ class LLP_Variation_Fields {
      * Enqueue admin scripts for media uploader and field handling.
      */
     public function enqueue_admin_scripts( $hook ) {
-        // Only enqueue scripts on product edit screens.
-        if ( ! in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
-            return;
-        }
-
         $screen = get_current_screen();
-        if ( empty( $screen ) || 'product' !== $screen->post_type ) {
+
+        if ( ! in_array( $hook, [ 'post.php', 'post-new.php' ], true ) || empty( $screen ) || 'product' !== $screen->post_type ) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- ensure admin scripts enqueue only for product edit screens

## Testing
- `php -l includes/class-llp-variation-fields.php`
- `phpcs includes/class-llp-variation-fields.php` *(fails: many style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f2c5dffc83338a721ad3d0648d7c