### PR TITLE
Capture image transforms and validate finalize request

### DIFF
--- a/woo-laser-photo-mockup/assets/js/frontend.js
+++ b/woo-laser-photo-mockup/assets/js/frontend.js
@@ -46,6 +46,7 @@ jQuery(function($){
     }
     canvas.on('object:moving', clamp);
     canvas.on('object:scaling', clamp);
+    canvas.on('object:rotating', clamp);
 
     function getTransform(){
         if(!fabricImg){
@@ -92,6 +93,8 @@ jQuery(function($){
 
     finalizeBtn.on('click', function(){
         if(!assetField.val()) return;
+        // Ensure we have the latest selected variation
+        currentVariation = $('input.variation_id').val() || currentVariation;
         var transform = getTransform();
         fetch(llpVars.restUrl + '/finalize', {
             method: 'POST',

--- a/woo-laser-photo-mockup/includes/class-llp-rest.php
+++ b/woo-laser-photo-mockup/includes/class-llp-rest.php
@@ -90,9 +90,9 @@ class LLP_REST {
      * Finalize and generate composite.
      */
     public function handle_finalize( WP_REST_Request $request ) {
-        $asset_id     = sanitize_text_field( $request['asset_id'] );
-        $variation_id = absint( $request['variation_id'] );
-        $transform    = $request['transform'];
+        $asset_id     = sanitize_text_field( $request->get_param( 'asset_id' ) );
+        $variation_id = absint( $request->get_param( 'variation_id' ) );
+        $transform    = $request->get_param( 'transform' );
 
         if ( empty( $asset_id ) ) {
             return new WP_Error( 'missing', __( 'Missing asset ID', 'llp' ), [ 'status' => 400 ] );
@@ -107,11 +107,9 @@ class LLP_REST {
         }
 
         $transform = wp_parse_args( $transform, [ 'crop' => [], 'scale' => 1, 'rotation' => 0 ] );
-        $crop      = wp_parse_args( $transform['crop'], [ 'x' => 0, 'y' => 0, 'width' => 0, 'height' => 0 ] );
-
-        foreach ( [ 'x', 'y', 'width', 'height' ] as $key ) {
-            $crop[ $key ] = floatval( $crop[ $key ] );
-        }
+        $crop      = is_array( $transform['crop'] ) ? $transform['crop'] : [];
+        $crop      = wp_parse_args( $crop, [ 'x' => 0, 'y' => 0, 'width' => 0, 'height' => 0 ] );
+        $crop      = array_map( 'floatval', array_intersect_key( $crop, array_flip( [ 'x', 'y', 'width', 'height' ] ) ) );
 
         $transform = [
             'crop'     => $crop,


### PR DESCRIPTION
## Summary
- track crop/scale/rotation on the frontend and send the selected variation id with finalize requests
- sanitize and validate transform data and variation id on finalize endpoint

## Testing
- `npm test` (fails: Could not read package.json)
- `phpunit` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a4f3a0143883338cb2fe6e8e1a8f66