### PR TITLE
Validate MIME types and sanitize uploaded images

### DIFF
--- a/woo-laser-photo-mockup/includes/class-llp-security.php
+++ b/woo-laser-photo-mockup/includes/class-llp-security.php
@@ -12,9 +12,9 @@ class LLP_Security {
         if ( $file['error'] !== UPLOAD_ERR_OK ) {
             return new WP_Error( 'upload', __( 'Upload error', 'llp' ) );
         }
-        $allowed   = explode( ',', LLP_Settings::get( 'allowed_mimes', 'jpg,jpeg,png,webp' ) );
-        $ext       = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
-        $wp_file   = wp_check_filetype( $file['name'] );
+        $allowed = explode( ',', LLP_Settings::get( 'allowed_mimes', 'jpg,jpeg,png,webp' ) );
+        $wp_file = wp_check_filetype_and_ext( $file['tmp_name'], $file['name'] );
+        $ext     = strtolower( $wp_file['ext'] );
 
         if ( ! in_array( $ext, $allowed, true ) || empty( $wp_file['type'] ) ) {
             return new WP_Error( 'mime', __( 'File type not allowed', 'llp' ) );

--- a/woo-laser-photo-mockup/includes/class-llp-storage.php
+++ b/woo-laser-photo-mockup/includes/class-llp-storage.php
@@ -21,13 +21,22 @@ class LLP_Storage {
         $this->ensure_asset_dir( $asset_id );
         $dir      = $this->asset_dir( $asset_id );
 
+        $wp_file = wp_check_filetype_and_ext( $file['tmp_name'], $file['name'] );
+        if ( empty( $wp_file['ext'] ) || empty( $wp_file['type'] ) ) {
+            return new WP_Error( 'mime', __( 'File type not allowed', 'llp' ) );
+        }
+
         $finfo = finfo_open( FILEINFO_MIME_TYPE );
         $mime  = $finfo ? finfo_file( $finfo, $file['tmp_name'] ) : '';
         if ( $finfo ) {
             finfo_close( $finfo );
         }
 
-        $ext  = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
+        if ( $mime !== $wp_file['type'] ) {
+            return new WP_Error( 'mime', __( 'File type mismatch', 'llp' ) );
+        }
+
+        $ext  = strtolower( $wp_file['ext'] );
         $dest = $dir . 'original.' . $ext;
 
         $processed = $this->reencode_image( $file['tmp_name'], $dest, $mime );


### PR DESCRIPTION
## Summary
- verify uploaded file types using `wp_check_filetype_and_ext` and PHP `finfo`
- cross-check MIME type before storing and re-encoding uploads
- ensure images are re-encoded to strip metadata and normalize orientation

## Testing
- `php -l includes/class-llp-security.php`
- `php -l includes/class-llp-storage.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4f5b255448333bfda8e86e31c58be