### PR TITLE
Add signed asset URL helper

### DIFF
--- a/woo-laser-photo-mockup/includes/class-llp-storage.php
+++ b/woo-laser-photo-mockup/includes/class-llp-storage.php
@@ -156,6 +156,32 @@ class LLP_Storage {
     }
 
     /**
+     * Get signed URLs for asset files.
+     *
+     * @param string $asset_id Asset identifier.
+     * @param int    $expires   URL lifetime in seconds.
+     * @return array
+     */
+    public function get_asset_urls( $asset_id, $expires = self::URL_TTL ) {
+        $paths = $this->get_asset_paths( $asset_id );
+        $urls  = [];
+
+        if ( ! empty( $paths['original'] ) && file_exists( $paths['original'] ) ) {
+            $urls['original'] = $this->url_for( $asset_id, basename( $paths['original'] ), $expires );
+        }
+
+        if ( file_exists( $paths['composite'] ) ) {
+            $urls['composite'] = $this->url_for( $asset_id, 'composite', $expires );
+        }
+
+        if ( file_exists( $paths['thumb'] ) ) {
+            $urls['thumb'] = $this->url_for( $asset_id, 'thumb', $expires );
+        }
+
+        return $urls;
+    }
+
+    /**
      * Build asset directory.
      */
     private function base_dir() {


### PR DESCRIPTION
## Summary
- expose `get_asset_urls` for generating signed links to original, composite and thumbnail assets

## Testing
- `php -l includes/class-llp-storage.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f6a3e0548333ac1310638b08a94a