### PR TITLE
Sanitize and label order item asset metadata

### DIFF
--- a/woo-laser-photo-mockup/includes/class-llp-order.php
+++ b/woo-laser-photo-mockup/includes/class-llp-order.php
@@ -12,22 +12,25 @@ class LLP_Order {
 
     /**
      * Persist meta to order item.
+     *
+     * Values are sanitized before storage so they can safely surface later in
+     * order screens and emails.
      */
     public function add_order_line_item( $item, $cart_item_key, $values, $order ) {
         if ( isset( $values['llp_asset_id'] ) ) {
-            $item->add_meta_data( '_llp_asset_id', $values['llp_asset_id'], true );
+            $item->add_meta_data( '_llp_asset_id', sanitize_text_field( $values['llp_asset_id'] ), true );
         }
         if ( isset( $values['llp_thumb_url'] ) ) {
-            $item->add_meta_data( '_llp_thumb_url', $values['llp_thumb_url'], true );
+            $item->add_meta_data( '_llp_thumb_url', esc_url_raw( $values['llp_thumb_url'] ), true );
         }
         if ( isset( $values['llp_composite_url'] ) ) {
-            $item->add_meta_data( '_llp_composite_url', $values['llp_composite_url'], true );
+            $item->add_meta_data( '_llp_composite_url', esc_url_raw( $values['llp_composite_url'] ), true );
         }
         if ( isset( $values['llp_original_url'] ) ) {
-            $item->add_meta_data( '_llp_original_url', $values['llp_original_url'], true );
+            $item->add_meta_data( '_llp_original_url', esc_url_raw( $values['llp_original_url'] ), true );
         }
         if ( isset( $values['llp_transform_json'] ) ) {
-            $item->add_meta_data( '_llp_transform_json', $values['llp_transform_json'], true );
+            $item->add_meta_data( '_llp_transform_json', sanitize_textarea_field( $values['llp_transform_json'] ), true );
         }
     }
 

--- a/woo-laser-photo-mockup/templates/emails/line-item-preview.php
+++ b/woo-laser-photo-mockup/templates/emails/line-item-preview.php
@@ -29,5 +29,6 @@
     </p>
 <?php endif; ?>
 <?php if ( ! empty( $transform_json ) ) : ?>
+    <p><?php esc_html_e( 'Transform JSON:', 'llp' ); ?></p>
     <pre style="white-space:pre-wrap;"><?php echo esc_html( $transform_json ); ?></pre>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- sanitize asset id, urls, and transform json before storing them on order items
- label transform json section in line item preview template for clarity

## Testing
- `php -l woo-laser-photo-mockup/includes/class-llp-order.php`
- `php -l woo-laser-photo-mockup/templates/emails/line-item-preview.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4f85845608333946a10637f2dd175