### PR TITLE
Add draggable overlay for capturing variation bounds

### DIFF
--- a/woo-laser-photo-mockup/assets/css/admin.css
+++ b/woo-laser-photo-mockup/assets/css/admin.css
@@ -1,1 +1,5 @@
 .llp-variation-fields { margin:10px 0; padding:10px; border:1px solid #ddd; }
+.llp-bounds-wrapper { position:relative; display:inline-block; margin:5px 0; }
+.llp-bounds-wrapper img.llp-base-image { display:block; max-width:100%; height:auto; }
+.llp-bounds-wrapper .llp-overlay { position:absolute; border:2px dashed #0073aa; background:rgba(0,115,170,0.2); cursor:move; }
+.llp-rotation-field { margin-top:5px; }

--- a/woo-laser-photo-mockup/assets/js/admin-variation.js
+++ b/woo-laser-photo-mockup/assets/js/admin-variation.js
@@ -15,12 +15,75 @@ jQuery(function($){
             });
             frame.on('select', function(){
                 var attachment = frame.state().get('selection').first().toJSON();
-                input.val(attachment.id);
+                input.val(attachment.id).trigger('change');
+                if(input.attr('name').indexOf('llp_base_image_id') !== -1){
+                    var container = button.closest('.llp-variation-fields');
+                    container.find('.llp-base-image').remove();
+                    container.find('.llp-bounds-wrapper').prepend('<img src="'+attachment.url+'" class="llp-base-image" />');
+                    setupBounds(container);
+                }
             });
             frame.open();
         });
     }
+
+    function setupBounds(container){
+        var wrapper = container.find('.llp-bounds-wrapper');
+        var overlay = wrapper.find('.llp-overlay');
+        var boundsInput = container.find('.llp-bounds-input');
+        var rotation = container.find('.llp-rotation');
+
+        if(!wrapper.find('.llp-base-image').length){
+            return;
+        }
+
+        wrapper.css('position','relative');
+        overlay.css('position','absolute');
+
+        if(overlay.data('ui-draggable')) overlay.draggable('destroy');
+        if(overlay.data('ui-resizable')) overlay.resizable('destroy');
+
+        overlay.draggable({ containment: 'parent', stop: updateBounds });
+        overlay.resizable({ containment: 'parent', stop: updateBounds });
+        rotation.off('input.llp change.llp').on('input.llp change.llp', updateBounds);
+
+        function updateBounds(){
+            var pos = overlay.position();
+            var rot = parseFloat(rotation.val()) || 0;
+            overlay.css('transform','rotate('+rot+'deg)');
+            var bounds = {
+                x: pos.left,
+                y: pos.top,
+                width: overlay.width(),
+                height: overlay.height(),
+                rotation: rot
+            };
+            boundsInput.val(JSON.stringify(bounds));
+        }
+
+        var existing = boundsInput.val();
+        if(existing){
+            try{
+                var data = JSON.parse(existing);
+                overlay.css({ left: data.x, top: data.y, width: data.width, height: data.height });
+                rotation.val(data.rotation || 0);
+                overlay.css('transform','rotate('+(data.rotation || 0)+'deg)');
+            }catch(err){
+                overlay.css({ left:0, top:0, width:100, height:100 });
+                rotation.val(0);
+            }
+        }else{
+            overlay.css({ left:0, top:0, width:100, height:100 });
+            rotation.val(0);
+        }
+        updateBounds();
+    }
+
     $('.llp-select-media').each(function(){
         initUploader($(this));
+    });
+
+    $('.llp-variation-fields').each(function(){
+        setupBounds($(this));
     });
 });

--- a/woo-laser-photo-mockup/includes/class-llp-variation-fields.php
+++ b/woo-laser-photo-mockup/includes/class-llp-variation-fields.php
@@ -23,7 +23,13 @@ class LLP_Variation_Fields {
 
         wp_enqueue_media();
         wp_enqueue_style( 'llp-admin', LLP_PLUGIN_URL . 'assets/css/admin.css', [], '1.0.0' );
-        wp_enqueue_script( 'llp-admin-variation', LLP_PLUGIN_URL . 'assets/js/admin-variation.js', [ 'jquery' ], '1.0.0', true );
+        wp_enqueue_script(
+            'llp-admin-variation',
+            LLP_PLUGIN_URL . 'assets/js/admin-variation.js',
+            [ 'jquery', 'jquery-ui-draggable', 'jquery-ui-resizable' ],
+            '1.0.0',
+            true
+        );
     }
 
     /**
@@ -33,6 +39,7 @@ class LLP_Variation_Fields {
         $base_id = get_post_meta( $variation->ID, '_llp_base_image_id', true );
         $mask_id = get_post_meta( $variation->ID, '_llp_mask_image_id', true );
         $bounds  = get_post_meta( $variation->ID, '_llp_bounds', true );
+        $base_src = $base_id ? wp_get_attachment_image_url( $base_id, 'full' ) : '';
         $aspect  = get_post_meta( $variation->ID, '_llp_aspect_ratio', true );
         $min_res = get_post_meta( $variation->ID, '_llp_min_resolution', true );
         $dpi     = get_post_meta( $variation->ID, '_llp_output_dpi', true );
@@ -48,9 +55,19 @@ class LLP_Variation_Fields {
                 <input type="hidden" class="llp-media-field" name="llp_mask_image_id[<?php echo esc_attr( $variation->ID ); ?>]" value="<?php echo esc_attr( $mask_id ); ?>" />
                 <button class="button llp-select-media"><?php esc_html_e( 'Select Mask', 'llp' ); ?></button>
             </p>
-            <p>
-                <label><?php esc_html_e( 'Bounds (JSON)', 'llp' ); ?></label>
-                <textarea name="llp_bounds[<?php echo esc_attr( $variation->ID ); ?>]" rows="2" cols="20"><?php echo esc_textarea( $bounds ); ?></textarea>
+            <p class="llp-bounds-field">
+                <label><?php esc_html_e( 'Bounds', 'llp' ); ?></label>
+                <input type="hidden" class="llp-bounds-input" name="llp_bounds[<?php echo esc_attr( $variation->ID ); ?>]" value="<?php echo esc_attr( $bounds ); ?>" />
+            </p>
+            <div class="llp-bounds-wrapper">
+                <?php if ( $base_src ) : ?>
+                    <img src="<?php echo esc_url( $base_src ); ?>" class="llp-base-image" alt="" />
+                <?php endif; ?>
+                <div class="llp-overlay"></div>
+            </div>
+            <p class="llp-rotation-field">
+                <label><?php esc_html_e( 'Rotation', 'llp' ); ?></label>
+                <input type="range" class="llp-rotation" min="0" max="360" value="0" />
             </p>
             <p>
                 <label><?php esc_html_e( 'Aspect Ratio (e.g. 4:3)', 'llp' ); ?></label>


### PR DESCRIPTION
## Summary
- enable draggable/resizable overlay on variation base images and persist bounds with rotation
- add JS logic to update `_llp_bounds` via interactive editor
- style admin overlay and load jQuery UI dependencies

## Testing
- `php -l includes/class-llp-variation-fields.php`
- `node --check assets/js/admin-variation.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4fa5277a08333aedde8cafc5c8613