### PR TITLE
Optimize admin script loading

### DIFF
--- a/woo-laser-photo-mockup/includes/class-llp-variation-fields.php
+++ b/woo-laser-photo-mockup/includes/class-llp-variation-fields.php
@@ -15,9 +15,12 @@ class LLP_Variation_Fields {
      * Enqueue admin scripts for media uploader and field handling.
      */
     public function enqueue_admin_scripts( $hook ) {
-        $screen = get_current_screen();
+        if ( ! in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
+            return;
+        }
 
-        if ( ! in_array( $hook, [ 'post.php', 'post-new.php' ], true ) || empty( $screen ) || 'product' !== $screen->post_type ) {
+        $screen = get_current_screen();
+        if ( empty( $screen ) || 'product' !== $screen->post_type ) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- ensure variation admin scripts load only on product editing screens
- avoid unnecessary calls to `get_current_screen`

## Testing
- `php -l woo-laser-photo-mockup/includes/class-llp-variation-fields.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4fc83848883339e6eb968ce3e5be5