### PR TITLE
Store transform data with order items

### DIFF
--- a/woo-laser-photo-mockup/includes/class-llp-order.php
+++ b/woo-laser-photo-mockup/includes/class-llp-order.php
@@ -29,8 +29,8 @@ class LLP_Order {
         if ( isset( $values['llp_original_url'] ) ) {
             $item->add_meta_data( '_llp_original_url', esc_url_raw( $values['llp_original_url'] ), true );
         }
-        if ( isset( $values['llp_transform_json'] ) ) {
-            $item->add_meta_data( '_llp_transform_json', sanitize_textarea_field( $values['llp_transform_json'] ), true );
+        if ( isset( $values['llp_transform'] ) ) {
+            $item->add_meta_data( '_llp_transform', sanitize_textarea_field( $values['llp_transform'] ), true );
         }
     }
 
@@ -51,7 +51,7 @@ class LLP_Order {
         $asset_id   = $item->get_meta( '_llp_asset_id', true );
         $composite  = $item->get_meta( '_llp_composite_url', true );
         $original   = $item->get_meta( '_llp_original_url', true );
-        $transform  = $item->get_meta( '_llp_transform_json', true );
+        $transform  = $item->get_meta( '_llp_transform', true );
 
         if ( ! $thumb && ! $asset_id && ! $composite && ! $original && ! $transform ) {
             return;

--- a/woo-laser-photo-mockup/templates/emails/line-item-preview.php
+++ b/woo-laser-photo-mockup/templates/emails/line-item-preview.php
@@ -18,13 +18,13 @@
 <?php if ( ! empty( $original_url ) || ! empty( $composite_url ) ) : ?>
     <p>
         <?php if ( ! empty( $original_url ) ) : ?>
-            <a href="<?php echo esc_url( $original_url ); ?>"><?php esc_html_e( 'Original', 'llp' ); ?></a>
+            <a href="<?php echo esc_url( $original_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Original', 'llp' ); ?></a>
         <?php endif; ?>
         <?php if ( ! empty( $original_url ) && ! empty( $composite_url ) ) : ?>
             |
         <?php endif; ?>
         <?php if ( ! empty( $composite_url ) ) : ?>
-            <a href="<?php echo esc_url( $composite_url ); ?>"><?php esc_html_e( 'Composite', 'llp' ); ?></a>
+            <a href="<?php echo esc_url( $composite_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Composite', 'llp' ); ?></a>
         <?php endif; ?>
     </p>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- Save transformation JSON on order line items via `_llp_transform`
- Display preview links in admin and emails with safer external link handling

## Testing
- `php -l woo-laser-photo-mockup/includes/class-llp-order.php`
- `php -l woo-laser-photo-mockup/templates/emails/line-item-preview.php`


------
https://chatgpt.com/codex/tasks/task_e_68a502587f0883338811df23d667e7d7