### PR TITLE
Add bounds overlay JSON storage

### DIFF
--- a/woo-laser-photo-mockup/assets/css/admin.css
+++ b/woo-laser-photo-mockup/assets/css/admin.css
@@ -1,5 +1,5 @@
 .llp-variation-fields { margin:10px 0; padding:10px; border:1px solid #ddd; }
 .llp-bounds-wrapper { position:relative; display:inline-block; margin:5px 0; }
 .llp-bounds-wrapper img.llp-base-image { display:block; max-width:100%; height:auto; }
-.llp-bounds-wrapper .llp-overlay { position:absolute; border:2px dashed #0073aa; background:rgba(0,115,170,0.2); cursor:move; }
+.llp-bounds-wrapper .llp-overlay { position:absolute; border:2px dashed #0073aa; background:rgba(0,115,170,0.2); cursor:move; box-sizing:border-box; }
 .llp-rotation-field { margin-top:5px; }

--- a/woo-laser-photo-mockup/assets/js/admin-variation.js
+++ b/woo-laser-photo-mockup/assets/js/admin-variation.js
@@ -52,10 +52,10 @@ jQuery(function($){
             var rot = parseFloat(rotation.val()) || 0;
             overlay.css('transform','rotate('+rot+'deg)');
             var bounds = {
-                x: pos.left,
-                y: pos.top,
-                width: overlay.width(),
-                height: overlay.height(),
+                x: Math.round(pos.left),
+                y: Math.round(pos.top),
+                width: Math.round(overlay.width()),
+                height: Math.round(overlay.height()),
                 rotation: rot
             };
             boundsInput.val(JSON.stringify(bounds));


### PR DESCRIPTION
## Summary
- Sanitize and persist variation overlay bounds as numeric JSON
- Round overlay coordinates on drag/resize events
- Ensure overlay dimensions include borders via box-sizing

## Testing
- `npm test` *(fails: package.json missing)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a504c98a80833399fad6ef632ef8e3