### PR TITLE
Ensure storage subsystem hooks register on init

### DIFF
--- a/woo-laser-photo-mockup/includes/class-llp-plugin.php
+++ b/woo-laser-photo-mockup/includes/class-llp-plugin.php
@@ -50,6 +50,8 @@ class LLP_Plugin {
         LLP_Frontend::instance();
         LLP_REST::instance();
         LLP_Order::instance();
+        LLP_Storage::instance();
+        LLP_Security::instance();
         LLP_Cron::instance();
     }
 }


### PR DESCRIPTION
## Summary
- Instantiate `LLP_Storage` and `LLP_Security` during subsystem initialization so asset routes are registered on every request

## Testing
- `php -l woo-laser-photo-mockup/includes/class-llp-plugin.php`
- `php test_route.php`

------
https://chatgpt.com/codex/tasks/task_e_68a508a4bab883338676e998f1cbec06