### PR TITLE
Use shared storage path for asset cleanup and uninstall

### DIFF
--- a/woo-laser-photo-mockup/includes/class-llp-cron.php
+++ b/woo-laser-photo-mockup/includes/class-llp-cron.php
@@ -24,14 +24,13 @@ class LLP_Cron {
      */
     public function daily_purge() {
         $retention = LLP_Settings::get( 'retention_days', 30 );
-        $upload    = wp_upload_dir();
-        $base      = trailingslashit( $upload['basedir'] ) . LLP_Storage::BASE_DIR;
+        $base      = LLP_Storage::instance()->base_dir();
         if ( ! is_dir( $base ) ) {
             return;
         }
         $threshold = time() - ( DAY_IN_SECONDS * $retention );
         $used       = LLP_Order::instance()->get_referenced_asset_ids();
-        foreach ( glob( $base . '/*', GLOB_ONLYDIR ) as $dir ) {
+        foreach ( glob( $base . '*', GLOB_ONLYDIR ) as $dir ) {
             $asset_id = basename( $dir );
             if ( in_array( $asset_id, $used, true ) ) {
                 continue;

--- a/woo-laser-photo-mockup/includes/class-llp-storage.php
+++ b/woo-laser-photo-mockup/includes/class-llp-storage.php
@@ -204,7 +204,7 @@ class LLP_Storage {
     /**
      * Build asset directory.
      */
-    private function base_dir() {
+    public function base_dir() {
         return trailingslashit( WP_CONTENT_DIR ) . self::BASE_DIR . '/';
     }
 

--- a/woo-laser-photo-mockup/uninstall.php
+++ b/woo-laser-photo-mockup/uninstall.php
@@ -12,11 +12,13 @@ delete_option( 'llp_settings' );
 // Optionally delete uploads directory if option set.
 $delete_assets = get_option( 'llp_delete_assets_on_uninstall', false );
 if ( $delete_assets ) {
-    $upload = wp_upload_dir();
-    $dir    = trailingslashit( $upload['basedir'] ) . 'llp';
+    require_once __DIR__ . '/traits/trait-singleton.php';
+    require_once __DIR__ . '/includes/class-llp-storage.php';
+
+    $dir = LLP_Storage::instance()->base_dir();
     if ( is_dir( $dir ) ) {
         // Recursively remove files.
-        $it = new RecursiveDirectoryIterator( $dir, RecursiveDirectoryIterator::SKIP_DOTS );
+        $it    = new RecursiveDirectoryIterator( $dir, RecursiveDirectoryIterator::SKIP_DOTS );
         $files = new RecursiveIteratorIterator( $it, RecursiveIteratorIterator::CHILD_FIRST );
         foreach ( $files as $file ) {
             if ( $file->isDir() ) {


### PR DESCRIPTION
## Summary
- Use `LLP_Storage`'s base directory when purging old assets
- Expose `LLP_Storage::base_dir()` for reuse
- Remove plugin storage directory on uninstall using the same base path

## Testing
- `php -l woo-laser-photo-mockup/includes/class-llp-storage.php`
- `php -l woo-laser-photo-mockup/includes/class-llp-cron.php`
- `php -l woo-laser-photo-mockup/uninstall.php`


------
https://chatgpt.com/codex/tasks/task_e_68a50990905c83338a9da05e50a0ce4b