### PR TITLE
Fix variation image picker

### DIFF
--- a/woo-laser-photo-mockup/assets/js/admin-variation.js
+++ b/woo-laser-photo-mockup/assets/js/admin-variation.js
@@ -1,31 +1,28 @@
 jQuery(function($){
-    function initUploader(button){
-        var frame;
-        button.on('click', function(e){
-            e.preventDefault();
-            var input = $(this).prev('.llp-media-field');
-            if(frame){
-                frame.open();
-                return;
-            }
-            frame = wp.media({
-                title: 'Select image',
-                button: {text: 'Use image'},
-                multiple: false
-            });
-            frame.on('select', function(){
-                var attachment = frame.state().get('selection').first().toJSON();
-                input.val(attachment.id).trigger('change');
-                if(input.attr('name').indexOf('llp_base_image_id') !== -1){
-                    var container = button.closest('.llp-variation-fields');
-                    container.find('.llp-base-image').remove();
-                    container.find('.llp-bounds-wrapper').prepend('<img src="'+attachment.url+'" class="llp-base-image" />');
-                    setupBounds(container);
-                }
-            });
-            frame.open();
+    function openUploader(button){
+        var input = button.prev('.llp-media-field');
+        var frame = wp.media({
+            title: 'Select image',
+            button: {text: 'Use image'},
+            multiple: false
         });
+        frame.on('select', function(){
+            var attachment = frame.state().get('selection').first().toJSON();
+            input.val(attachment.id).trigger('change');
+            if(input.attr('name').indexOf('llp_base_image_id') !== -1){
+                var container = button.closest('.llp-variation-fields');
+                container.find('.llp-base-image').remove();
+                container.find('.llp-bounds-wrapper').prepend('<img src="'+attachment.url+'" class="llp-base-image" />');
+                setupBounds(container);
+            }
+        });
+        frame.open();
     }
+
+    $(document).on('click', '.llp-select-media', function(e){
+        e.preventDefault();
+        openUploader($(this));
+    });
 
     function setupBounds(container){
         var wrapper = container.find('.llp-bounds-wrapper');
@@ -79,11 +76,12 @@ jQuery(function($){
         updateBounds();
     }
 
-    $('.llp-select-media').each(function(){
-        initUploader($(this));
-    });
+    function initBounds(){
+        $('.llp-variation-fields').each(function(){
+            setupBounds($(this));
+        });
+    }
 
-    $('.llp-variation-fields').each(function(){
-        setupBounds($(this));
-    });
+    $(document).on('woocommerce_variations_loaded woocommerce_variation_added', initBounds);
+    initBounds();
 });

--- a/woo-laser-photo-mockup/includes/class-llp-variation-fields.php
+++ b/woo-laser-photo-mockup/includes/class-llp-variation-fields.php
@@ -51,12 +51,12 @@ class LLP_Variation_Fields {
             <p>
                 <label><?php esc_html_e( 'Base Image', 'llp' ); ?></label>
                 <input type="hidden" class="llp-media-field" name="llp_base_image_id[<?php echo esc_attr( $variation->ID ); ?>]" value="<?php echo esc_attr( $base_id ); ?>" />
-                <button class="button llp-select-media"><?php esc_html_e( 'Select Image', 'llp' ); ?></button>
+                <button type="button" class="button llp-select-media"><?php esc_html_e( 'Select Image', 'llp' ); ?></button>
             </p>
             <p>
                 <label><?php esc_html_e( 'Mask Image', 'llp' ); ?></label>
                 <input type="hidden" class="llp-media-field" name="llp_mask_image_id[<?php echo esc_attr( $variation->ID ); ?>]" value="<?php echo esc_attr( $mask_id ); ?>" />
-                <button class="button llp-select-media"><?php esc_html_e( 'Select Mask', 'llp' ); ?></button>
+                <button type="button" class="button llp-select-media"><?php esc_html_e( 'Select Mask', 'llp' ); ?></button>
             </p>
             <p class="llp-bounds-field">
                 <label><?php esc_html_e( 'Bounds', 'llp' ); ?></label>


### PR DESCRIPTION
## Summary
- prevent variation media buttons from submitting the product form
- reinitialize media picker and bounds when WooCommerce variations load dynamically
- remove bundled plugin ZIP from repository

## Testing
- `php -l woo-laser-photo-mockup/includes/class-llp-variation-fields.php`
- `node --check woo-laser-photo-mockup/assets/js/admin-variation.js`


------
https://chatgpt.com/codex/tasks/task_e_68a50783a53483338c28cb90346bfeb6