### PR TITLE
Allow customers to upload and finalize images via REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,5 +170,19 @@ meta.json
 
 ---
 
+## Manual Testing
+
+1. **Customer upload & finalize**
+   - Log in as a user with the `customer` role.
+   - Obtain a REST nonce from the storefront (e.g., `wpApiSettings.nonce`).
+   - `POST /wp-json/llp/v1/upload` with the nonce and a valid image file.
+   - `POST /wp-json/llp/v1/finalize` using the returned `asset_id` and a variation ID.
+   - Both requests should return `200` responses.
+2. **Unauthorized requests**
+   - Repeat the above steps while logged out or without a nonce.
+   - Requests to `/upload` or `/finalize` should return `401`/`403` errors.
+
+---
+
 ## License
 MIT – Internal project for WooCommerce customization.

--- a/woo-laser-photo-mockup/includes/class-llp-rest.php
+++ b/woo-laser-photo-mockup/includes/class-llp-rest.php
@@ -16,11 +16,13 @@ class LLP_REST {
         register_rest_route( 'llp/v1', '/upload', [
             'methods'             => 'POST',
             'callback'            => [ $this, 'handle_upload' ],
+            // Logged-in customers are allowed via authorize_request().
             'permission_callback' => [ $this, 'authorize_request' ],
         ] );
         register_rest_route( 'llp/v1', '/finalize', [
             'methods'             => 'POST',
             'callback'            => [ $this, 'handle_finalize' ],
+            // Logged-in customers are allowed via authorize_request().
             'permission_callback' => [ $this, 'authorize_request' ],
         ] );
 
@@ -138,10 +140,11 @@ class LLP_REST {
     }
 
     /**
-     * Ensure the user is logged in and can act on the specified order if one is provided.
+     * Ensure the user is logged in and has basic access before acting on the specified order.
      */
     private function check_order_capabilities( WP_REST_Request $request ) {
-        if ( ! is_user_logged_in() || ! current_user_can( 'upload_files' ) ) {
+        // Allow any logged-in user with read access (e.g. customers).
+        if ( ! is_user_logged_in() || ! current_user_can( 'read' ) ) {
             return new WP_Error( 'rest_forbidden', __( 'You are not allowed to perform this action', 'llp' ), [ 'status' => rest_authorization_required_code() ] );
         }
 


### PR DESCRIPTION
## Summary
- Permit any logged-in user with `read` capability to upload and finalize images
- Document manual steps for verifying customer and unauthorized access

## Testing
- `php -l woo-laser-photo-mockup/includes/class-llp-rest.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a56d6b31388333a915006df9dcb927