### PR TITLE
Limit editor box size and make responsive

### DIFF
--- a/woo-laser-photo-mockup/assets/css/frontend.css
+++ b/woo-laser-photo-mockup/assets/css/frontend.css
@@ -1,5 +1,6 @@
 .llp-customizer { margin-bottom: 1em; }
 .llp-preview { margin-top:0.5em; }
 .llp-preview img { max-width: 100%; height: auto; display:block; border:1px solid #ccc; }
+.llp-editor { max-width:400px; width:100%; margin:0 auto; }
 .llp-editor img { max-width:100%; border:1px solid #ccc; display:block; }
 #llp-finalize { margin-top:0.5em; }

--- a/woo-laser-photo-mockup/assets/js/frontend.js
+++ b/woo-laser-photo-mockup/assets/js/frontend.js
@@ -12,6 +12,18 @@ jQuery(function($){
 
     var cropperImg = $('#llp-canvas');
     var cropper = null;
+    var MAX_EDITOR_SIZE = 400;
+
+    function scaleBounds(bounds, max){
+        var ratio = Math.min(max / bounds.width, max / bounds.height, 1);
+        return {
+            x: bounds.x,
+            y: bounds.y,
+            width: bounds.width * ratio,
+            height: bounds.height * ratio,
+            rotation: bounds.rotation
+        };
+    }
 
     function getBounds(){
         if(window.llpBounds && window.llpBounds[currentVariation]){
@@ -21,7 +33,7 @@ jQuery(function($){
     }
 
     function initCropper(url){
-        var bounds = getBounds();
+        var bounds = scaleBounds(getBounds(), MAX_EDITOR_SIZE);
         editor.show().css({width:bounds.width, height:bounds.height});
         preview.show();
         cropperImg.attr('src', url);
@@ -63,7 +75,7 @@ jQuery(function($){
         if(!cropper) return;
         var transform = getTransform();
         transformField.val(JSON.stringify(transform));
-        var bounds = getBounds();
+        var bounds = scaleBounds(getBounds(), MAX_EDITOR_SIZE);
         var canvas = cropper.getCroppedCanvas({ width: bounds.width, height: bounds.height });
         if(canvas){
             previewImg.attr('src', canvas.toDataURL());


### PR DESCRIPTION
## Summary
- Clamp editor dimensions to a 400px max to avoid oversized boxes
- Make editor container responsive with max-width styling

## Testing
- `npm test` *(fails: missing package.json)*
- `node -e "const max=400;function scaleBounds(b,max){var r=Math.min(max/b.width,max/b.height,1);return {width:b.width*r,height:b.height*r};}console.log(scaleBounds({width:800,height:600},max));console.log(scaleBounds({width:200,height:300},max));"`


------
https://chatgpt.com/codex/tasks/task_e_68a56f4458d88333a80114811556bfa8