### PR TITLE
Re-enable add to cart after finalize failure

### DIFF
--- a/woo-laser-photo-mockup/assets/js/frontend.js
+++ b/woo-laser-photo-mockup/assets/js/frontend.js
@@ -154,8 +154,7 @@ jQuery(function($){
             }
         }).catch(function(){
             $(document.body).trigger('wc_add_notice', ['Error finalizing image. Please try again.', 'error']);
-            finalizeBtn.prop('disabled', false);
-            addToCartBtn.prop('disabled', false);
+            $('.single_add_to_cart_button').prop('disabled', false);
         }).finally(function(){
             finalizeBtn.prop('disabled', false);
         });


### PR DESCRIPTION
## Summary
- Re-enable `.single_add_to_cart_button` if image finalize fails so users can retry
- Leave finalize button disabled only until the request completes

## Testing
- `npm test` (fails: Could not read package.json)
- Simulated finalize failure and verified add-to-cart button re-enables

------
https://chatgpt.com/codex/tasks/task_e_68a57030e9e08333b7844050158e410e