### PR TITLE
Improve customizer responsiveness

### DIFF
--- a/woo-laser-photo-mockup/assets/css/frontend.css
+++ b/woo-laser-photo-mockup/assets/css/frontend.css
@@ -1,7 +1,7 @@
 .llp-customizer { margin-bottom: 1em; }
-.llp-preview { margin-top:0.5em; }
+.llp-preview { margin-top:0.5em; max-width:800px; width:100%; margin-left:auto; margin-right:auto; }
 .llp-preview img { max-width: 100%; height: auto; display:block; border:1px solid #ccc; }
-.llp-editor { max-width:400px; width:100%; margin:0 auto; }
+.llp-editor { max-width:800px; width:100%; margin:0 auto; }
 .llp-editor img { max-width:100%; border:1px solid #ccc; display:block; }
 #llp-finalize { margin-top:0.5em; }
 

--- a/woo-laser-photo-mockup/assets/js/frontend.js
+++ b/woo-laser-photo-mockup/assets/js/frontend.js
@@ -13,7 +13,12 @@ jQuery(function($){
 
     var cropperImg = $('#llp-canvas');
     var cropper = null;
-    var MAX_EDITOR_SIZE = 400;
+    var MAX_EDITOR_LIMIT = 800;
+
+    function getMaxEditorSize(){
+        var width = editor.parent().width();
+        return Math.min(width || MAX_EDITOR_LIMIT, MAX_EDITOR_LIMIT);
+    }
 
     function scaleBounds(bounds, max){
         var ratio = Math.min(max / bounds.width, max / bounds.height, 1);
@@ -34,7 +39,7 @@ jQuery(function($){
     }
 
     function initCropper(url){
-        var bounds = scaleBounds(getBounds(), MAX_EDITOR_SIZE);
+        var bounds = scaleBounds(getBounds(), getMaxEditorSize());
         editor.show().css({width:bounds.width, height:bounds.height});
         preview.show();
         cropperImg.attr('src', url);
@@ -76,7 +81,7 @@ jQuery(function($){
         if(!cropper) return;
         var transform = getTransform();
         transformField.val(JSON.stringify(transform));
-        var bounds = scaleBounds(getBounds(), MAX_EDITOR_SIZE);
+        var bounds = scaleBounds(getBounds(), getMaxEditorSize());
         var canvas = cropper.getCroppedCanvas({ width: bounds.width, height: bounds.height });
         if(canvas){
             previewImg.attr('src', canvas.toDataURL());


### PR DESCRIPTION
## Summary
- Size editor canvas based on parent width with an 800px cap
- Allow editor and preview to expand up to 800px for fluid product layout

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a5753707c48333a6566ca3fde104c6