### PR TITLE
Fix customizer button overlap

### DIFF
--- a/woo-laser-photo-mockup/assets/css/frontend.css
+++ b/woo-laser-photo-mockup/assets/css/frontend.css
@@ -3,7 +3,7 @@
 .llp-preview img { max-width: 100%; height: auto; display:block; border:1px solid #ccc; }
 .llp-editor { max-width:800px; width:100%; margin:0 auto; }
 .llp-editor img { max-width:100%; border:1px solid #ccc; display:block; }
-#llp-finalize { margin-top:0.5em; }
+#llp-finalize { display:block; margin:0.75em auto 0; }
 
 .llp-drop-zone {
     display:block;

--- a/woo-laser-photo-mockup/assets/js/frontend.js
+++ b/woo-laser-photo-mockup/assets/js/frontend.js
@@ -40,7 +40,7 @@ jQuery(function($){
 
     function initCropper(url){
         var bounds = scaleBounds(getBounds(), getMaxEditorSize());
-        editor.show().css({width:bounds.width, height:bounds.height});
+        editor.show().css({width:bounds.width});
         preview.show();
         cropperImg.attr('src', url);
         if(cropper){ cropper.destroy(); }

--- a/woo-laser-photo-mockup/templates/single-product/customizer.php
+++ b/woo-laser-photo-mockup/templates/single-product/customizer.php
@@ -12,8 +12,8 @@
     </div>
     <div id="llp-editor" class="llp-editor" style="display:none;">
         <img id="llp-canvas" src="" alt="" />
-        <p><button type="button" id="llp-finalize" class="button">Finalize</button></p>
     </div>
+    <p><button type="button" id="llp-finalize" class="button">Finalize</button></p>
     <div id="llp-preview" class="llp-preview" style="display:none;">
         <img src="" alt="" />
     </div>


### PR DESCRIPTION
## Summary
- ensure finalize button renders below cropper without overlap
- style finalize button with spacing
- remove fixed height on editor initialization

## Testing
- `npm test` *(fails: ENOENT, missing package.json)*
- `php -l woo-laser-photo-mockup/templates/single-product/customizer.php`
- `composer test` *(fails: Command "test" is not defined.)*


------
https://chatgpt.com/codex/tasks/task_e_68a576542c948333be08dae3c2a66189