### PR TITLE
Align mask overlay with scaled bounds

### DIFF
--- a/woo-laser-photo-mockup/assets/js/frontend.js
+++ b/woo-laser-photo-mockup/assets/js/frontend.js
@@ -23,8 +23,8 @@ jQuery(function($){
     function scaleBounds(bounds, max){
         var ratio = Math.min(max / bounds.width, max / bounds.height, 1);
         return {
-            x: bounds.x,
-            y: bounds.y,
+            x: bounds.x * ratio,
+            y: bounds.y * ratio,
             width: bounds.width * ratio,
             height: bounds.height * ratio,
             rotation: bounds.rotation
@@ -56,7 +56,7 @@ jQuery(function($){
             cropBoxMovable:false,
             cropBoxResizable:false,
             ready: function(){
-                cropper.setCropBoxData({ width: bounds.width, height: bounds.height });
+                cropper.setCropBoxData({ left: bounds.x, top: bounds.y, width: bounds.width, height: bounds.height });
                 updateTransform();
             },
             crop: function(){


### PR DESCRIPTION
## Summary
- Scale variation bounds' x/y positions alongside width/height in `scaleBounds`
- Position cropper mask overlay using scaled coordinates to honor variation bounds

## Testing
- `npm test` (fails: Could not read package.json)
- `composer test` (fails: Command "test" is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68a5771f5cdc83339e73f0e9e6a0a4c8