### PR TITLE
Capture composite and original URLs for orders

### DIFF
--- a/woo-laser-photo-mockup/assets/js/frontend.js
+++ b/woo-laser-photo-mockup/assets/js/frontend.js
@@ -7,6 +7,8 @@ jQuery(function($){
     var finalizeBtn = $('#llp-finalize');
     var assetField  = $('#llp-asset-id');
     var thumbField  = $('#llp-thumb-url');
+    var originalField = $('#llp-original-url');
+    var compositeField = $('#llp-composite-url');
     var transformField = $('#llp-transform');
     var currentVariation = $('input.variation_id').val() || 0;
     var addToCartBtn = $('.single_add_to_cart_button').prop('disabled', true);
@@ -98,6 +100,8 @@ jQuery(function($){
         var file = this.files[0];
         if(!file) return;
         addToCartBtn.prop('disabled', true);
+        originalField.val('');
+        compositeField.val('');
         var reader = new FileReader();
         reader.onload = function(e){
             initCropper(e.target.result);
@@ -173,10 +177,16 @@ jQuery(function($){
             if(res2.thumb){
                 previewImg.attr('src', res2.thumb);
                 thumbField.val(res2.thumb);
-                preview.show();
-                editor.hide();
-                addToCartBtn.prop('disabled', false);
             }
+            if(res2.original){
+                originalField.val(res2.original);
+            }
+            if(res2.composite){
+                compositeField.val(res2.composite);
+            }
+            preview.show();
+            editor.hide();
+            addToCartBtn.prop('disabled', false);
         }).catch(function(){
             $(document.body).trigger('wc_add_notice', ['Error finalizing image. Please try again.', 'error']);
             $('.single_add_to_cart_button').prop('disabled', false);

--- a/woo-laser-photo-mockup/includes/class-llp-frontend.php
+++ b/woo-laser-photo-mockup/includes/class-llp-frontend.php
@@ -61,6 +61,12 @@ class LLP_Frontend {
         if ( isset( $_POST['llp_thumb_url'] ) ) {
             $cart_item_data['llp_thumb_url'] = esc_url_raw( $_POST['llp_thumb_url'] );
         }
+        if ( isset( $_POST['llp_original_url'] ) ) {
+            $cart_item_data['llp_original_url'] = esc_url_raw( $_POST['llp_original_url'] );
+        }
+        if ( isset( $_POST['llp_composite_url'] ) ) {
+            $cart_item_data['llp_composite_url'] = esc_url_raw( $_POST['llp_composite_url'] );
+        }
         return $cart_item_data;
     }
 
@@ -86,6 +92,12 @@ class LLP_Frontend {
         }
         if ( isset( $values['llp_thumb_url'] ) ) {
             $cart_item['llp_thumb_url'] = $values['llp_thumb_url'];
+        }
+        if ( isset( $values['llp_original_url'] ) ) {
+            $cart_item['llp_original_url'] = $values['llp_original_url'];
+        }
+        if ( isset( $values['llp_composite_url'] ) ) {
+            $cart_item['llp_composite_url'] = $values['llp_composite_url'];
         }
         return $cart_item;
     }

--- a/woo-laser-photo-mockup/includes/class-llp-rest.php
+++ b/woo-laser-photo-mockup/includes/class-llp-rest.php
@@ -222,6 +222,9 @@ class LLP_REST {
         if ( is_wp_error( $result ) ) {
             return $result;
         }
-        return rest_ensure_response( $result );
+
+        $urls = LLP_Storage::instance()->get_asset_urls( $asset_id );
+        $response = array_merge( [ 'asset_id' => $asset_id ], $urls );
+        return rest_ensure_response( $response );
     }
 }

--- a/woo-laser-photo-mockup/templates/emails/line-item-preview.php
+++ b/woo-laser-photo-mockup/templates/emails/line-item-preview.php
@@ -10,7 +10,7 @@
  */
 ?>
 <?php if ( ! empty( $thumb_url ) ) : ?>
-    <p><img src="<?php echo esc_url( $thumb_url ); ?>" alt="" style="max-width:80px;" /></p>
+    <p><img src="<?php echo esc_url( $thumb_url ); ?>" alt="" style="max-width:150px;" /></p>
 <?php endif; ?>
 <?php if ( ! empty( $asset_id ) ) : ?>
     <p><?php printf( esc_html__( 'Asset ID: %s', 'llp' ), esc_html( $asset_id ) ); ?></p>

--- a/woo-laser-photo-mockup/templates/single-product/customizer.php
+++ b/woo-laser-photo-mockup/templates/single-product/customizer.php
@@ -19,6 +19,8 @@
     </div>
     <input type="hidden" name="llp_asset_id" id="llp-asset-id" />
     <input type="hidden" name="llp_thumb_url" id="llp-thumb-url" />
+    <input type="hidden" name="llp_original_url" id="llp-original-url" />
+    <input type="hidden" name="llp_composite_url" id="llp-composite-url" />
     <input type="hidden" name="llp_transform" id="llp-transform" />
 </div>
 


### PR DESCRIPTION
## Summary
- Save original and composite image URLs from finalize endpoint and expose them via frontend JS
- Persist original/composite URLs through cart data so order items include links
- Enlarge email preview thumbnail to 150px

## Testing
- `php -l woo-laser-photo-mockup/includes/class-llp-frontend.php`
- `php -l woo-laser-photo-mockup/includes/class-llp-rest.php`
- `php -l woo-laser-photo-mockup/templates/single-product/customizer.php`
- `php -l woo-laser-photo-mockup/templates/emails/line-item-preview.php`
- `node --check woo-laser-photo-mockup/assets/js/frontend.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a5785e09648333b3fbd92519498250