### PR TITLE
Center customizer editor and preview images

### DIFF
--- a/woo-laser-photo-mockup/assets/css/frontend.css
+++ b/woo-laser-photo-mockup/assets/css/frontend.css
@@ -1,8 +1,43 @@
-.llp-customizer { margin-bottom: 1em; }
-.llp-preview { margin-top:0.5em; max-width:800px; width:100%; margin-left:auto; margin-right:auto; }
-.llp-preview img { max-width: 100%; height: auto; display:block; border:1px solid #ccc; }
-.llp-editor { max-width:800px; width:100%; margin:0 auto; }
-.llp-editor img { max-width:100%; border:1px solid #ccc; display:block; }
+.llp-customizer {
+    margin-bottom: 1em;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.llp-preview {
+    margin-top: 0.5em;
+    max-width: 800px;
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    display: flex;
+    justify-content: center;
+}
+
+.llp-preview img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    border: 1px solid #ccc;
+    margin: 0 auto;
+}
+
+.llp-editor {
+    max-width: 800px;
+    width: 100%;
+    margin: 0 auto;
+    display: flex;
+    justify-content: center;
+}
+
+.llp-editor img {
+    max-width: 100%;
+    border: 1px solid #ccc;
+    display: block;
+    margin: 0 auto;
+}
 #llp-finalize { display:block; margin:0.75em auto 0; }
 
 .llp-drop-zone {


### PR DESCRIPTION
## Summary
- Center `.llp-customizer`, `.llp-editor`, and `.llp-preview` using flexbox so images align with product content.
- Ensure embedded images are centered and bounded within containers.

## Testing
- `NODE_PATH=$(npm root -g) node - <<'NODE' ...` (puppeteer check: verified centering at 320, 768, 1024 widths)
- `npm test` (fails: Could not read package.json)
- `php -l woo-laser-photo-mockup.php`


------
https://chatgpt.com/codex/tasks/task_e_68a579729e8c8333bb9378e482fdf121