### PR TITLE
Improve image mask selection UX for variations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Woo Laser Photo Mockup is a custom WooCommerce plugin that enables customers to 
   - Preview visible in cart, checkout, order details, and emails.
 
 - **Admin (Backend)**
-  - Variation editor: base image, mask, placement editor (drag/resize box).
+  - Variation editor: base image, mask with preview, placeholders, removal, and placement editor (drag/resize box).
   - Configure bounds, aspect ratio, min resolution, DPI.
   - Order view: preview thumbnail, open full image, re-render, purge uploads.
   - Auto-purge files N days after order is marked completed.

--- a/woo-laser-photo-mockup/assets/css/admin.css
+++ b/woo-laser-photo-mockup/assets/css/admin.css
@@ -3,3 +3,12 @@
 .llp-bounds-wrapper img.llp-base-image { display:block; max-width:100%; height:auto; }
 .llp-bounds-wrapper .llp-overlay { position:absolute; border:2px dashed #0073aa; background:rgba(0,115,170,0.2); cursor:move; box-sizing:border-box; }
 .llp-rotation-field { margin-top:5px; }
+.llp-image-preview img { display:block; max-width:80px; height:auto; margin-top:5px; }
+.llp-remove-media { margin-left:5px; }
+.llp-image-preview:empty::before {
+    content: attr(data-placeholder);
+    display: block;
+    margin-top: 5px;
+    color: #666;
+    font-style: italic;
+}

--- a/woo-laser-photo-mockup/assets/js/admin-variation.js
+++ b/woo-laser-photo-mockup/assets/js/admin-variation.js
@@ -1,14 +1,17 @@
 jQuery(function($){
     function openUploader(button){
-        var input = button.prev('.llp-media-field');
+        var input      = button.prev('.llp-media-field');
         var frame = wp.media({
-            title: 'Select image',
-            button: {text: 'Use image'},
+            title: button.data('title') || 'Select image',
+            button: {text: button.data('button') || 'Use image'},
             multiple: false
         });
         frame.on('select', function(){
             var attachment = frame.state().get('selection').first().toJSON();
             input.val(attachment.id).trigger('change');
+            var img = $('<img>', { src: attachment.url, alt: attachment.alt || attachment.title || '' });
+            button.siblings('.llp-image-preview').html(img);
+            button.siblings('.llp-remove-media').show();
             if(input.attr('name').indexOf('llp_base_image_id') !== -1){
                 var container = button.closest('.llp-variation-fields');
                 container.find('.llp-base-image').remove();
@@ -22,6 +25,22 @@ jQuery(function($){
     $(document).on('click', '.llp-select-media', function(e){
         e.preventDefault();
         openUploader($(this));
+    });
+
+    $(document).on('click', '.llp-remove-media', function(e){
+        e.preventDefault();
+        var button = $(this);
+        var input  = button.siblings('.llp-media-field');
+        input.val('').trigger('change');
+        button.siblings('.llp-image-preview').empty();
+        button.hide();
+        if(input.attr('name').indexOf('llp_base_image_id') !== -1){
+            var container = button.closest('.llp-variation-fields');
+            container.find('.llp-base-image').remove();
+            container.find('.llp-overlay').removeAttr('style');
+            container.find('.llp-bounds-input').val('');
+            container.find('.llp-rotation').val('0').trigger('change');
+        }
     });
 
     function setupBounds(container){

--- a/woo-laser-photo-mockup/includes/class-llp-variation-fields.php
+++ b/woo-laser-photo-mockup/includes/class-llp-variation-fields.php
@@ -51,12 +51,16 @@ class LLP_Variation_Fields {
             <p>
                 <label><?php esc_html_e( 'Base Image', 'llp' ); ?></label>
                 <input type="hidden" class="llp-media-field" name="llp_base_image_id[<?php echo esc_attr( $variation->ID ); ?>]" value="<?php echo esc_attr( $base_id ); ?>" />
-                <button type="button" class="button llp-select-media"><?php esc_html_e( 'Select Image', 'llp' ); ?></button>
+                <button type="button" class="button llp-select-media" data-title="<?php esc_attr_e( 'Select Base Image', 'llp' ); ?>" data-button="<?php esc_attr_e( 'Use Image', 'llp' ); ?>"><?php esc_html_e( 'Select Image', 'llp' ); ?></button>
+                <button type="button" class="button llp-remove-media" <?php echo $base_id ? '' : 'style="display:none;"'; ?>><?php esc_html_e( 'Remove', 'llp' ); ?></button>
+                <span class="llp-image-preview" data-placeholder="<?php esc_attr_e( 'No image selected', 'llp' ); ?>"><?php echo $base_id ? wp_get_attachment_image( $base_id, 'thumbnail', false, [ 'alt' => esc_attr__( 'Base image preview', 'llp' ) ] ) : ''; ?></span>
             </p>
             <p>
                 <label><?php esc_html_e( 'Mask Image', 'llp' ); ?></label>
                 <input type="hidden" class="llp-media-field" name="llp_mask_image_id[<?php echo esc_attr( $variation->ID ); ?>]" value="<?php echo esc_attr( $mask_id ); ?>" />
-                <button type="button" class="button llp-select-media"><?php esc_html_e( 'Select Mask', 'llp' ); ?></button>
+                <button type="button" class="button llp-select-media" data-title="<?php esc_attr_e( 'Select Mask', 'llp' ); ?>" data-button="<?php esc_attr_e( 'Use Mask', 'llp' ); ?>"><?php esc_html_e( 'Select Mask', 'llp' ); ?></button>
+                <button type="button" class="button llp-remove-media" <?php echo $mask_id ? '' : 'style="display:none;"'; ?>><?php esc_html_e( 'Remove', 'llp' ); ?></button>
+                <span class="llp-image-preview" data-placeholder="<?php esc_attr_e( 'No image selected', 'llp' ); ?>"><?php echo $mask_id ? wp_get_attachment_image( $mask_id, 'thumbnail', false, [ 'alt' => esc_attr__( 'Mask image preview', 'llp' ) ] ) : ''; ?></span>
             </p>
             <p class="llp-bounds-field">
                 <label><?php esc_html_e( 'Bounds', 'llp' ); ?></label>
@@ -64,7 +68,7 @@ class LLP_Variation_Fields {
             </p>
             <div class="llp-bounds-wrapper">
                 <?php if ( $base_src ) : ?>
-                    <img src="<?php echo esc_url( $base_src ); ?>" class="llp-base-image" alt="" />
+                    <img src="<?php echo esc_url( $base_src ); ?>" class="llp-base-image" alt="<?php esc_attr_e( 'Base image preview', 'llp' ); ?>" />
                 <?php endif; ?>
                 <div class="llp-overlay"></div>
             </div>


### PR DESCRIPTION
## Summary
- show previews and removal buttons for base and mask images
- handle preview/remove in variation editor JS with custom uploader titles
- add admin styles for image previews
- display placeholders and alt text for accessibility, resetting rotation when base image cleared

## Testing
- `php -l woo-laser-photo-mockup/includes/class-llp-variation-fields.php`
- `node --check woo-laser-photo-mockup/assets/js/admin-variation.js`
- `npm test` *(fails: Could not read package.json)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57c14e9188333800b4c8a1b1a9383